### PR TITLE
[Fix] svgr 라이브러리 prettier 충돌 문제 해결

### DIFF
--- a/Lotte-Cinema/package.json
+++ b/Lotte-Cinema/package.json
@@ -8,19 +8,16 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "svgr": "npx @svgr/cli -d src/assets/svg --ignore-existing --typescript --no-dimensions public/svg",
+    "svgr": "npx @svgr/cli -d src/assets/svg --ignore-existing --typescript --no-prettier --no-dimensions public/svg",
     "lint:styled": "stylelint './src/**/*.{ts,tsx}' --fix"
   },
   "dependencies": {
-
     "@tanstack/react-query": "^5.60.5",
     "@tanstack/react-query-devtools": "^5.60.5",
     "axios": "^1.7.7",
-
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "glob": "^9.0.0",
-
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",


### PR DESCRIPTION
## 🔥 Related Issues
- close #18 


## 💙 작업 내용
- [x] svgr/cli 라이브러리 script에 `--no-prettier` 옵션  추가

## ✅ PR Point
`svgr/cli`와 `prettier`와 충돌이 일어나서 `SVGSVGElement` 제네릭이 잘 추가가 안되는 문제가 있어서 `--no-prettier` 옵션으로 .svg를 .tsx로 바꿀  때는 prettier 적용 안되도록 했습니다! 


## 😡 Trouble Shooting
아직 자세한 원인을 찾지는 못했지만 svg를 tsx로 변환하는 과정에서 prettier와 충돌이 일어나서 제대로 된 타입 (제네릭) 지정이 안되는 것 같습니다. 더 찾아보고 문서로 남기겠습니다! 

https://github.com/gregberge/svgr/issues/893
svgr cli와 prettier가 break 된다는 스택 오버# 🔥 Related Issues
- close #18 


## 💙 작업 내용
- [x] svgr/cli 라이브러리 script에 `--no-prettier` 옵션  추가

## ✅ PR Point
`svgr/cli`와 `prettier`와 충돌이 일어나서 `SVGSVGElement` 제네릭이 잘 추가가 안되는 문제가 있어서 `--no-prettier` 옵션으로 .svg를 .tsx로 바꿀  때는 prettier 적용 안되도록 했습니다! 


## 😡 Trouble Shooting
아직 자세한 원인을 찾지는 못했지만 svg를 tsx로 변환하는 과정에서 prettier와 충돌이 일어나서 제대로 된 타입 (제네릭) 지정이 안되는 것 같습니다. 더 찾아보고 문서로 남기겠습니다! 

https://github.com/gregberge/svgr/issues/893
svgr cli와 prettier가 break 된다는 이슈 관련 링크 첨부하겠습니다!

## 👀 스크린샷 / GIF / 링크
![image](https://github.com/user-attachments/assets/7f742591-83d2-48e3-b8b9-63520015993e)

![image](https://github.com/user-attachments/assets/42a61554-fb44-44df-9a2c-567f5e357b1e)

